### PR TITLE
Add test for multisig signer

### DIFF
--- a/src/signer.ts
+++ b/src/signer.ts
@@ -73,11 +73,11 @@ export function makeMultiSigAccountTransactionSigner(
         partialSigs.push(blob);
       }
 
-      if (partialSigs.length > 1) {
-        signed.push(mergeMultisigTransactions(partialSigs));
-      } else {
-        signed.push(partialSigs[0]);
-      }
+      // if (partialSigs.length > 1) {
+      signed.push(mergeMultisigTransactions(partialSigs));
+      // } else {
+      //   signed.push(partialSigs[0]);
+      // }
     }
 
     return Promise.resolve(signed);

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -73,11 +73,11 @@ export function makeMultiSigAccountTransactionSigner(
         partialSigs.push(blob);
       }
 
-      // if (partialSigs.length > 1) {
-      signed.push(mergeMultisigTransactions(partialSigs));
-      // } else {
-      //   signed.push(partialSigs[0]);
-      // }
+      if (partialSigs.length > 1) {
+        signed.push(mergeMultisigTransactions(partialSigs));
+      } else {
+        signed.push(partialSigs[0]);
+      }
     }
 
     return Promise.resolve(signed);


### PR DESCRIPTION
Adds a unit test for signing 1 multisig signer. Confirmed that source code change fixes this behavior.